### PR TITLE
':' deprectaed in 'case' syntax as of Ruby 1.9

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -76,6 +76,15 @@ e.g. SugarCRM::Contacts.find_by_title("VP of Sales") will work, but SugarCRM::Co
   
   # Use the HTTP Connection and SugarCRM API to load the Admin user
   SugarCRM.connection.get_entry("Users", 1)
+  
+  # Retrieve the first 10 Accounts with a zip code between 10000 and 10500
+  SugarCRM::Account.all(
+  {
+    :conditions => { :primary_address_postalcode => ["> '10000'", "<= '10500'" ] },
+    :limit => '10',
+    :order_by => 'primary_address_postalcode'
+  }
+)
 
   # Retrieve all Accounts by user name (direct API method)
   SugarCRM.connection.get_entry_list(

--- a/lib/sugarcrm/attribute_methods.rb
+++ b/lib/sugarcrm/attribute_methods.rb
@@ -54,9 +54,9 @@ module SugarCRM; module AttributeMethods
       case attr_type_for(attribute)
       when "bool"
         case @attributes[attribute]
-        when TrueClass:
+        when TrueClass
           next
-        when FalseClass:
+        when FalseClass
           next
         else
           @errors.add "#{attribute} must be true or false"

--- a/lib/sugarcrm/base.rb
+++ b/lib/sugarcrm/base.rb
@@ -270,7 +270,7 @@ module SugarCRM; class Base
     end
     
     VALID_FIND_OPTIONS = [ :conditions, :include, :joins, :limit, :offset,
-                           :order, :select, :readonly, :group, :having, :from, :lock ]
+                           :order_by, :select, :readonly, :group, :having, :from, :lock ]
 
     def validate_find_options(options) #:nodoc:
       options.assert_valid_keys(VALID_FIND_OPTIONS)

--- a/lib/sugarcrm/base.rb
+++ b/lib/sugarcrm/base.rb
@@ -129,20 +129,23 @@ module SugarCRM; class Base
       # If we dont have conditions, just return an empty query
       return "" unless options[:conditions]
       conditions = []
-      options[:conditions].each_pair do |column, value| 
-      
-        # parse operator in cases where (e.g.) :attribute => '>= some_value', fallback to '=' operator as default
-        operator = value.to_s[/^([<>=]*)(.*)$/,1]
-        operator = '=' if operator.nil? || operator.strip == ''
+      options[:conditions].each_pair do |column, v| 
+        v = [] << v unless v.class == Array
         
-        value = $2 # strip the operator from value passed to query
-        value = value.strip[/'?([^']*)'?/,1]
-        unless column =~ /_c$/ # attribute name ending with _c implies a custom attribute
-          condition_attribute = "#{self._module.table_name}.#{column}"
-        else
-          condition_attribute = column # if setting a condition on a customer attribute, don't add model table name (or query breaks)
-        end
-        conditions << "#{condition_attribute} #{operator} \'#{value}\'"
+        v.each{|value|
+          # parse operator in cases where (e.g.) :attribute => '>= some_value', fallback to '=' operator as default
+          operator = value.to_s[/^([<>=]*)(.*)$/,1]
+          operator = '=' if operator.nil? || operator.strip == ''
+          
+          value = $2 # strip the operator from value passed to query
+          value = value.strip[/'?([^']*)'?/,1]
+          unless column =~ /_c$/ # attribute name ending with _c implies a custom attribute
+            condition_attribute = "#{self._module.table_name}.#{column}"
+          else
+            condition_attribute = column # if setting a condition on a customer attribute, don't add model table name (or query breaks)
+          end
+          conditions << "#{condition_attribute} #{operator} \'#{value}\'"
+        }
       end
       conditions.join(" AND ")
     end

--- a/lib/sugarcrm/base.rb
+++ b/lib/sugarcrm/base.rb
@@ -130,7 +130,19 @@ module SugarCRM; class Base
       return "" unless options[:conditions]
       conditions = []
       options[:conditions].each_pair do |column, value| 
-        conditions << "#{self._module.table_name}.#{column} = \'#{value}\'"
+      
+        # parse operator in cases where (e.g.) :attribute => '>= some_value', fallback to '=' operator as default
+        operator = value.to_s[/^([<>=]*)(.*)$/,1]
+        operator = '=' if operator.nil? || operator.strip == ''
+        
+        value = $2 # strip the operator from value passed to query
+        value = value.strip[/'?([^']*)'?/,1]
+        unless column =~ /_c$/ # attribute name ending with _c implies a custom attribute
+          condition_attribute = "#{self._module.table_name}.#{column}"
+        else
+          condition_attribute = column # if setting a condition on a customer attribute, don't add model table name (or query breaks)
+        end
+        conditions << "#{condition_attribute} #{operator} \'#{value}\'"
       end
       conditions.join(" AND ")
     end


### PR DESCRIPTION
fixed 'case' syntax to work with Ruby 1.9 (using ':' in cases raises a syntax error)

This change should be backwards compatible with Ruby 1.8
