### PR TITLE
    add basic support for SQL operators (such as LIKE, IS NOT, etc... ) in search queries

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -115,6 +115,11 @@ Instead of SugarCRM.connection.get_entry("Users", "1") you could use SugarCRM::U
     :conditions => { :billing_address_postalcode => "<> NULL" }
   })
   
+  # Retrieve all Accounts with 'Fund' in their name
+  SugarCRM::Account.all({
+    :conditions => { :name => "LIKE '%Fund%'" } # note that SQL operators must be uppercase
+  })
+  
   # Look up the fields for a given module
   SugarCRM::Module.find("Accounts").fields
   

--- a/lib/sugarcrm/base.rb
+++ b/lib/sugarcrm/base.rb
@@ -161,12 +161,13 @@ module SugarCRM; class Base
         v = [] << v unless v.class == Array
         
         v.each{|value|
-          # parse operator in cases where (e.g.) :attribute => '>= some_value', fallback to '=' operator as default
-          operator = value.to_s[/^([<>=]*)(.*)$/,1]
-          operator = '=' if operator.nil? || operator.strip == ''
+          # parse operator in cases where (e.g.) :attribute => '>= some_value', :attribute => "LIKE '%value%'", fallback to '=' operator as default
+          operator = value.to_s[/^([!<>=]*(LIKE|IS|NOT|\s)*)(.*)$/,1]
+          operator.strip! if operator
+          operator = '=' if operator.nil? || operator == ''
           
-          value = $2 # strip the operator from value passed to query
-          value = value.strip[/'?([^']*)'?/,1]
+          value = $3 # extract value from query
+          value = value.strip[/'?([^']*)'?/,1] # strip single quotes around value, if present
           conditions << "#{table_name_for(column)}.#{column} #{operator} \'#{value}\'"
         }
       end

--- a/lib/sugarcrm/module.rb
+++ b/lib/sugarcrm/module.rb
@@ -15,7 +15,17 @@ module SugarCRM
       @name   = name
       @klass  = name.classify
       @table_name = name.tableize
-      @custom_table_name = @table_name + "_cstm"
+      
+      # set table name for custom attibutes
+      # custom attributes are contained in a table named after the module, with a '_cstm' suffix
+      # the module's table name must be tableized for the modules that ship with SugarCRM
+      # for custom modules (created in the Studio), table name don't need to be tableized: the name passed to the constructor is already tableized
+      unless name.downcase == name # this module is a custom module (custom module names are all lower_case, whereas SugarCRM modules are CamelCase
+        @custom_table_name = @table_name + "_cstm"
+      else
+        @custom_table_name = name + "_cstm"
+      end
+      
       @fields = {}
       @link_fields = {}
       @fields_registered = false

--- a/test/test_sugarcrm.rb
+++ b/test/test_sugarcrm.rb
@@ -97,6 +97,13 @@ class TestSugarCRM < Test::Unit::TestCase
       assert_instance_of SugarCRM::Account, accounts.first
     end
     
+    should "support searching based on SQL operators" do
+      accounts = SugarCRM::Account.all({
+        :conditions => { :name => "LIKE '%Fund%'" }
+      })
+      assert_instance_of SugarCRM::Account, accounts.first
+    end
+    
     should "return an an instance of itself when sent #find(id)" do
       assert_instance_of SugarCRM::User, SugarCRM::User.find(1)
     end


### PR DESCRIPTION
Seems like the pull request works now...
