### PR TITLE
Return `nil` (instead of false) if no results are found

### DIFF
--- a/lib/sugarcrm/base.rb
+++ b/lib/sugarcrm/base.rb
@@ -158,7 +158,7 @@ module SugarCRM; class Base
         
     def find_by_sql(options)
       query = query_from_options(options)
-      SugarCRM.connection.get_entry_list(self._module.name, query, options)
+      SugarCRM.connection.get_entry_list(self._module.name, query, options) || nil # return nil instead of false if no results are found
     end
 
     def query_from_options(options)

--- a/lib/sugarcrm/base.rb
+++ b/lib/sugarcrm/base.rb
@@ -41,12 +41,7 @@ module SugarCRM; class Base
         when :first
           find_initial(options)
         when :all
-          results = find_every(options)
-          if results
-            Array.wrap(results)
-          else
-            []
-          end
+          Array.wrap(find_every(options)).compact
         else
           find_from_ids(args, options)
       end


### PR DESCRIPTION
Makes more sense to me, and is more consistent with commit https://github.com/chicks/sugarcrm/commit/515068985267077b4058c5120b6e5fcc3dbdb28e

Should be backwards compatible for boolean tests:
result = SugarCRM::Contact.find_by_first_name('blah')
process(result) if result # should work the same as it did when false was returned
