### PR TITLE
Rails23 backport

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "activesupport", ">= 3.0.0", :require => "active_support"
+gem "activesupport", ">= 2.3.10", :require => "active_support"
 gem "i18n"
 gem "json"
 

--- a/lib/sugarcrm/attributes/attribute_validations.rb
+++ b/lib/sugarcrm/attributes/attribute_validations.rb
@@ -1,7 +1,7 @@
 module SugarCRM; module AttributeValidations
   # Checks to see if we have all the neccessary attributes
   def valid?
-    @errors = ActiveSupport::HashWithIndifferentAccess.new
+    @errors = (defined?(HashWithIndifferentAccess) ? HashWithIndifferentAccess : ActiveSupport::HashWithIndifferentAccess).new
     
     self.class._module.required_fields.each do |attribute|
       valid_attribute?(attribute)

--- a/lib/sugarcrm/session.rb
+++ b/lib/sugarcrm/session.rb
@@ -102,10 +102,11 @@ module SugarCRM; class Session
   end
   
   # load credentials from file, and (re)connect to SugarCRM
-  def load_config(path)
+  def load_config(path, opts = {})
+    opts.reverse_merge! :reconnect => true
     new_config = self.class.parse_config_file(path)
-    @config[:config] = new_config[:config] if new_config
-    reconnect(@config[:base_url], @config[:username], @config[:password]) if connection_info_loaded?
+    update_config(new_config[:config]) if new_config and new_config[:config]
+    reconnect(@config[:base_url], @config[:username], @config[:password]) if opts[:reconnect] and connection_info_loaded?
     @config
   end
   

--- a/test/connection/test_get_entry_list.rb
+++ b/test/connection/test_get_entry_list.rb
@@ -2,12 +2,13 @@ require 'helper'
 
 class TestGetEntryList < ActiveSupport::TestCase
   context "A SugarCRM.connection" do
-    should "return a list of entries when sent #get_entry_list and no fields." do
+    should "return a list of entries when sent #get_entry_list" do
       users = SugarCRM.connection.get_entry_list(
         "Users",
         "users.deleted = 0"
       )
-      assert_equal "admin", users.first.user_name
+      assert_kind_of Array, users
+      assert_equal SugarCRM.config[:username], users.first.user_name
     end
     should "return an object when #get_entry_list" do
       @response = SugarCRM.connection.get_entry_list(

--- a/test/connection/test_get_module_fields.rb
+++ b/test/connection/test_get_module_fields.rb
@@ -4,7 +4,7 @@ class TestModuleFields < ActiveSupport::TestCase
   context "A SugarCRM.connection" do
     should "return a hash of module fields when #get_module_fields" do
       fields = SugarCRM.connection.get_module_fields("Users")
-      assert_instance_of ActiveSupport::HashWithIndifferentAccess, fields
+      assert_kind_of Hash, fields
       assert "address_city", fields.keys[0]
     end
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'test/unit'
 require 'shoulda'
+require 'active_support/test_case'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))

--- a/test/test_finders.rb
+++ b/test/test_finders.rb
@@ -5,9 +5,9 @@ class TestFinders < ActiveSupport::TestCase
     should "always return an Array when :all" do
       users = SugarCRM::User.all(:limit => 10)
       assert_instance_of Array, users
-      users = SugarCRM::User.find(:all, :conditions => {:user_name => '= admin'})
+      users = SugarCRM::User.find(:all, :conditions => {:user_name => "= #{users.first.user_name}"})
       assert_instance_of Array, users
-      assert users.length == 1
+      assert_equal 1, users.length
       users = SugarCRM::User.find(:all, :conditions => {:user_name => '= invalid_user_123'})
       assert_instance_of Array, users
       assert users.length == 0
@@ -101,12 +101,12 @@ class TestFinders < ActiveSupport::TestCase
     
     should "receive a response containing all fields when sent #get_entry" do
       u = SugarCRM::User.find(1)
-      assert_equal u.user_name, "admin"
+      assert_not_nil u.user_name
     end
     
     should "return an array of records when sent #find([id1, id2, id3])" do
       users = SugarCRM::User.find(["seed_sarah_id", 1])
-      assert_equal "admin", users.last.user_name
+      assert_not_nil users.last.user_name
     end
     
     # test Base#find_by_sql edge case

--- a/test/test_session.rb
+++ b/test/test_session.rb
@@ -15,6 +15,7 @@ CONFIG_CONTENTS.freeze
 class TestSession < ActiveSupport::TestCase
   context "The SugarCRM::Session class" do
     should "raise SugarCRM::MissingCredentials if at least one of url/username/password is missing" do
+      
       assert_raise(SugarCRM::MissingCredentials){ SugarCRM.connect('http://127.0.0.1/sugarcrm', nil, nil) }
     end
     
@@ -33,7 +34,7 @@ class TestSession < ActiveSupport::TestCase
     end
     
     should "parse config parameters from a file" do
-      assert_equal CONFIG_CONTENTS, SugarCRM::Session.parse_config_file(CONFIG_PATH)
+      assert_equal CONFIG_CONTENTS, SugarCRM::Session.parse_config_file(CONFIG_TEST_PATH)
     end
     
     should "create a session from a config file" do
@@ -59,8 +60,9 @@ class TestSession < ActiveSupport::TestCase
     end
     
     should "load config file" do
-      SugarCRM.load_config CONFIG_TEST_PATH
+      SugarCRM.load_config CONFIG_TEST_PATH, :reconnect => false
       CONFIG_CONTENTS[:config].each{|k,v| assert_equal v, SugarCRM.config[k]}
+      SugarCRM.load_config CONFIG_PATH
     end
     
     should "be able to disconnect, and log in to Sugar automatically if credentials are present in config file" do

--- a/test/test_sugarcrm.rb
+++ b/test/test_sugarcrm.rb
@@ -13,7 +13,7 @@ class TestSugarCRM < ActiveSupport::TestCase
     
     should "implement self.count" do
       nb_accounts = SugarCRM::Account.count
-      assert nb_accounts > 0
+      assert nb_accounts > 0, "There should be some Accounts"
       nb_inc_accounts = nil
       assert_nothing_raised do
         nb_inc_accounts = SugarCRM::Account.count(:conditions => {:name => "LIKE '%Inc'"})
@@ -38,7 +38,7 @@ class TestSugarCRM < ActiveSupport::TestCase
     end
     
     should "return the module fields" do
-      assert_instance_of ActiveSupport::HashWithIndifferentAccess, SugarCRM::Account._module.fields
+      assert_kind_of Hash, SugarCRM::Account._module.fields
     end
     
     should "respond to self#methods" do
@@ -59,7 +59,7 @@ class TestSugarCRM < ActiveSupport::TestCase
     end
   
     should "respond to self.attributes_from_modules_fields" do
-      assert_instance_of ActiveSupport::HashWithIndifferentAccess, SugarCRM::User.attributes_from_module
+      assert_kind_of Hash, SugarCRM::User.attributes_from_module
     end
   
     should "return an instance of itself when #new" do


### PR DESCRIPTION
This changes makes the sugarcrm gem usable with activesupport 2.3

this changes also makes the tests more independent from the specific SugarCRM-Server running on localhost with predefined admin-username
