### PR TITLE
Updated association method

### DIFF
--- a/lib/sugarcrm/associations/association.rb
+++ b/lib/sugarcrm/associations/association.rb
@@ -34,6 +34,7 @@ module SugarCRM
       return true if attribute.class == @target
       return true if attribute == link_field
       return true if methods.include? attribute
+      return true if attribute.link_fields.include? link_field
       false
     end
     


### PR DESCRIPTION
Updated association.rb include? method to match link_field

This is necessary when @target=false (as is the case for many (all?) custom modules)
